### PR TITLE
Add contrib instructions

### DIFF
--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -4,7 +4,7 @@
 
 <footer class="site-footer">
 <p>
-  These docs are in active development. Please come back soon to see even more resources.
+  These resources are in active development. <a href="/how-to-contribute">Want to contribute?</a>
 </p>
 <p>
   Creative Commons Attribution 4.0 International License. <a href="https://probablefutures.org/licensing/">Read more about Probable Futures licensing.</a>

--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: How to contribute
+nav_order: 5
+---
+
+# How to contribute to Probable Futures open-source projects
+
+If you plan to contribute code or documentation to Probable Futures open source projects, you must have a [GitHub account](https://github.com/signup/free) so you can open Pull Requests.
+
+To begin contributing, please [fork](http://help.github.com/forking) the project repository that you would like to contribute to from among the [Probable Futures open-source projects](https://github.com/Probable-Futures/). Then, [create a Pull Request](https://help.github.com/articles/creating-a-pull-request/). When your Pull Request is ready to be reviewed and merged, please add [MoustafaWehbe](https://github.com/MoustafaWehbe) as a reviewer or tag Moustafa in a GitHub comment or in a message in our #developer-resources channel in the [Alpha Group Slack organization](https://probablefutures.org/alpha-program/?tab=about).
+
+If you have suggestions, ideas, or contributions outside the scope of open-source project contributions, please [contact us](https://probablefutures.org/contact/).

--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -10,4 +10,4 @@ If you plan to contribute code or documentation to Probable Futures open source
 
 To begin contributing, please [fork](http://help.github.com/forking) the project repository that you would like to contribute to from among the [Probable Futures open-source projects](https://github.com/Probable-Futures/). Then, [create a Pull Request](https://help.github.com/articles/creating-a-pull-request/). When your Pull Request is ready to be reviewed and merged, please add [MoustafaWehbe](https://github.com/MoustafaWehbe) as a reviewer or tag Moustafa in a GitHub comment or in a message in our #developer-resources channel in the [Alpha Group Slack organization](https://probablefutures.org/alpha-program/?tab=about).
 
-If you have suggestions, ideas, or contributions outside the scope of open-source project contributions, please [contact us](https://probablefutures.org/contact/).
+If you have thoughts, feedback, or ideas beyond the scope of open-source project contributions, please [contact us](https://probablefutures.org/contact/).


### PR DESCRIPTION
This PR adds contributor instructions to the public documentation. It is intended to make our open source contribution process clear and easy for public contributors so they can focus on their contribution and not worry about the logistics of how their contribution will be incorporated into its respective project. 