### PR TITLE
fix: quick bug fixes with links and code examples

### DIFF
--- a/calling-the-api.md
+++ b/calling-the-api.md
@@ -128,7 +128,6 @@ var requestOptions = {
   method: 'POST',
   headers: headers,
   body: graphql,
-  redirect: 'follow'
 };
 
 fetch("https://graphql.probablefutures.org/graphql", requestOptions)
@@ -175,7 +174,6 @@ var requestOptions = {
   method: 'POST',
   headers: myHeaders,
   body: graphql,
-  redirect: 'follow'
 };
 
 fetch("https://graphql.probablefutures.org/graphql", requestOptions)

--- a/mapbox-quick-start.md
+++ b/mapbox-quick-start.md
@@ -9,12 +9,12 @@ parent: Maps
 
 Start working with Probable Futures maps in less than five minutes with this simple guide.  
 
-We will use [Mapbox Studio](studio.mapbox.com) to quickly get started with a Mapbox's excellent visual map editing experience. If you don't have a Mapbox account, you will need to create one to use Mapbox Studio.
+We will use [Mapbox Studio](https://studio.mapbox.com) to quickly get started with a Mapbox's excellent visual map editing experience. If you don't have a Mapbox account, you will need to create one to use Mapbox Studio.
 
 Follow these steps to get started:
 
 1. Download a Mapbox style JSON file from the Probable Futures [map styles folder in Github](https://github.com/Probable-Futures/docs/tree/main/mapStyles).
-2. On the [Mapbox Studio styles page](studio.mapbox.com), click the "New style" button. Then click the "Upload Style" tab.
+2. On the [Mapbox Studio styles page](https://studio.mapbox.com), click the "New style" button. Then click the "Upload Style" tab.
 3. Upload the JSON file you downloaded from the Probable Futures map styles folder in Github.
 4. Finally, click the "Customize" button to view and edit the map.
 

--- a/maps.md
+++ b/maps.md
@@ -7,7 +7,7 @@ has_children: true
 
 # The maps
 
-The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md). To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures.data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
+The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md) with a resolution of 0.2°latitude/longitude per grid cell side. To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures-data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
 
 ## All maps
 


### PR DESCRIPTION
Fixed the links to some pages on the docs and on probablefutures.org and removed code that gave me issues within the examples. I also added another reference to the resolution of the climate models (0.2° per grid box side) for clarity, although I'm not sure if this placement is ultimately the best spot for it.