### PR TITLE
Reorganization of Information and Definitions Page

### DIFF
--- a/calling-the-api.md
+++ b/calling-the-api.md
@@ -128,7 +128,6 @@ var requestOptions = {
   method: 'POST',
   headers: headers,
   body: graphql,
-  redirect: 'follow'
 };
 
 fetch("https://graphql.probablefutures.org/graphql", requestOptions)
@@ -175,7 +174,6 @@ var requestOptions = {
   method: 'POST',
   headers: myHeaders,
   body: graphql,
-  redirect: 'follow'
 };
 
 fetch("https://graphql.probablefutures.org/graphql", requestOptions)

--- a/definitions.md
+++ b/definitions.md
@@ -3,19 +3,24 @@ layout: default
 title: Definitions
 nav_order: 5
 ---
-## Important Definitions to Know Working with Probable Futures
+## Definitions 
+The following terms are important to know and understand when working with Probable Futures maps and data. 
 
-*Warming/Climate Scenarios*: Measured in units of 0.5°C, each warming scenario is a model of the climate at the given temperature increase. A more detailed explanation can be found on [Understanding climate scenarios](/understanding-climate-scenarios.md).
+*Probable Futures maps and data*: Probable Futures maps and data refer to different ways of viewing or interacting with the same datasets. When they are visualized, we refer to them as maps. When they are viewed as numbers, we refer to them as data. They make the most sense when viewed as maps because they are maps of global climate data in different scenarios. See the full list of maps on the [Maps](/maps.md) page. 
 
-*Statistical Percentiles & Range of Values*: On Probable Futures Maps and the Probable Futures API, data points are represented by a low, mid, and high value.  
+*Warming/Climate Scenarios*: Measured in units of 0.5°C, each warming scenario is a model of the climate at the given temperature increase from before warming began prior to the 1900s. A more detailed explanation can be found on [Understanding climate scenarios](/understanding-climate-scenarios.md).
+
+*Grid Cells*: [Climate models](https://probablefutures.org/science/climate-models/) split the world into a grid and model the climate within each grid cell during a given climate scenario. Probable Futures maps have a resolution of 0.2° latitude and longitude per side of each grid cell which is approximately the size of a typical city’s metro area, or about 22km squared. This is the highest resolution data we offer because higher resolutions have diminishing returns: if there is a drought in one 22km area, there is also a drought in the 22km area next to it. [Read more about the data](/probable-futures-data#journey-of-the-data.md). 
+
+*Statistical Percentiles & Range of Values*: Every grid cell in every Probable Futures map contains a low, mid, and high value.  
 | PF Value | Percentile Value| Explanation |
 | ---------| ----------------| ------------|
-| Low      | 5th | These conditions should be expected in approximately 5% of possible scenarios. At the low end of the range of possibilities. |
-| Mid      | 50th (Median) or Mean Value*| Conditions near this value should be expected in a typical year. Expected in approximately 50% of possible scenarios. |
-| High     | 95th | These conditions should be expected in approximately 5% of possible scenarios - at the high end of the range of possiblilties. |
+| Low      | 5th | Conditions like these should be expected approximately 5% of the time during the given warming scenario. Lower values could also occur in this warming scenario with lower likelihood than this value. For example, in a map of the average temperature, this value would represent a cool year in the location of the grid cell, but not the coolest possible year. |
+| Mid      | 50th (Median) or Mean Value*| Conditions near this value should be expected in a typical year during the given warming scenario. For example, in a map of the average temperature, this value would represent a typical or moderate year in the location of the grid cell. |
+| High     | 95th | Conditions like these should be expected approximately 5% of the time during the given warming scenario. Higher values could also occur in this warming scenario with lower likelihood than this value. For example, in a map of the average temperature, this value would represent a warm year in the location of the grid cell, but not the warmest possible year. |
 
 *See [Note on average and median values](/probable-futures-data#note-on-average-and-median-values.md)
 
-*Grid Cells*: The [climate models we use](https://probablefutures.org/science/climate-models/) split the world into a grid and model the climate within each grid cell. Probable Futures maps have a resolution of 0.2° latitude and longitude per side of each grid cell which is approximately the size of a typical city’s metro area. This is the most specific data available on Probable Futures currently. [More](/probable-futures-data#journey-of-the-data.md) 
+
 
 <!-- add map bins and regional climate model definitions here -->

--- a/definitions.md
+++ b/definitions.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Definitions
+nav_order: 5
+---
+## Important Definitions to Know Working with Probable Futures
+
+*Warming/Climate Scenarios*: Measured in units of 0.5°C, each warming scenario is a model of the climate at the given temperature increase. A more detailed explanation can be found on [Understanding climate scenarios](/understanding-climate-scenarios.md).
+
+*Statistical Percentiles & Range of Values*: On Probable Futures Maps and the Probable Futures API, data points are represented by a low, mid, and high value.  
+| PF Value | Percentile Value| Explanation |
+| ---------| ----------------| ------------|
+| Low      | 5th | These conditions should be expected in approximately 5% of possible scenarios. At the low end of the range of possibilities. |
+| Mid      | 50th (Median) or Mean Value*| Conditions near this value should be expected in a typical year. Expected in approximately 50% of possible scenarios. |
+| High     | 95th | These conditions should be expected in approximately 5% of possible scenarios - at the high end of the range of possiblilties. |
+
+*See [Note on average and median values](/probable-futures-data#note-on-average-and-median-values.md)
+
+*Grid Cells*: The [climate models we use](https://probablefutures.org/science/climate-models/) split the world into a grid and model the climate within each grid cell. Probable Futures maps have a resolution of 0.2° latitude and longitude per side of each grid cell which is approximately the size of a typical city’s metro area. This is the most specific data available on Probable Futures currently. [More](/probable-futures-data#journey-of-the-data.md) 
+
+<!-- add map bins and regional climate model definitions here -->

--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: How to contribute
-nav_order: 5
+nav_order: 6
 ---
 
 # How to contribute to Probable Futures open-source projects

--- a/mapbox-quick-start.md
+++ b/mapbox-quick-start.md
@@ -9,12 +9,12 @@ parent: Maps
 
 Start working with Probable Futures maps in less than five minutes with this simple guide.  
 
-We will use [Mapbox Studio](studio.mapbox.com) to quickly get started with a Mapbox's excellent visual map editing experience. If you don't have a Mapbox account, you will need to create one to use Mapbox Studio.
+We will use [Mapbox Studio](https://studio.mapbox.com) to quickly get started with a Mapbox's excellent visual map editing experience. If you don't have a Mapbox account, you will need to create one to use Mapbox Studio.
 
 Follow these steps to get started:
 
 1. Download a Mapbox style JSON file from the Probable Futures [map styles folder in Github](https://github.com/Probable-Futures/docs/tree/main/mapStyles).
-2. On the [Mapbox Studio styles page](studio.mapbox.com), click the "New style" button. Then click the "Upload Style" tab.
+2. On the [Mapbox Studio styles page](https://studio.mapbox.com), click the "New style" button. Then click the "Upload Style" tab.
 3. Upload the JSON file you downloaded from the Probable Futures map styles folder in Github.
 4. Finally, click the "Customize" button to view and edit the map.
 

--- a/maps.md
+++ b/maps.md
@@ -7,7 +7,7 @@ has_children: true
 
 # The maps
 
-The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md) with a resolution of 0.2°latitude/longitude per grid cell side. To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures-data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
+The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md) with a resolution of 0.2° latitude/longitude per grid cell side. To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures-data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
 
 ## All maps
 

--- a/maps.md
+++ b/maps.md
@@ -7,7 +7,7 @@ has_children: true
 
 # The maps
 
-The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md). To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures.data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
+The Probable Futures maps are climate model data displayed as [Mapbox tilesets](/tilesets.md) with a resolution of 0.2°latitude/longitude per grid cell side. To learn more about climate models and the specific models Probable Futures uses, please see [About the data](/probable-futures-data.md) and [the Science page](https://probablefutures.org/science/) on probablefutures.org.
 
 ## All maps
 

--- a/probable-futures-data.md
+++ b/probable-futures-data.md
@@ -16,6 +16,38 @@ Climate models are created and maintained by scientific institutions around the 
 
 These institutions make their models available for download. Organizations that do climate model work, including those you may have heard of like the IPCC, analyze the models to produce predictions about future climate and weather which are often published in long written reports with charts, maps, and graphs. Although climate models have technically been publicly available for a long time, analyzing and interpreting them directly requires so much specialized climate science knowledge that few people outside of climate scientists have actually done so. Probable Futures makes climate models available and accessible to anyone, anywhere. [See "Who makes climate models?" on the Science page for more](https://probablefutures.org/science/climate-models/).
 
+## About the Data in Probable Futures Maps
+### Range of Expected Values
+
+Probable Futures maps contain low, mid, and high values for each location and warming scenario. You can think of these values as a range. People must be prepared for the full range in the same way we all must be prepared for a range of weather. In other words, this range can be thought of as potential outcomes in any given year in the specified warming scenario for the specified location.
+
+In some places, the ranges of potential outcomes are wider. For those of us who live in places that can be both very hot and very cold, we know this well. We must own different types of clothing for summer and winter. In other places, ranges are narrower. In places with narrower ranges, people don't need so many different types of clothing.
+
+As the climate changes, these ranges change in every place. The range of values in the API offer an opportunity to prepare for ranges of outcomes that are manageable and to seek changes in human actions that can help avoid ranges in warming scenarios that are unmanageable.
+
+The low and high values are not the lowest or highest possible values that could occur in the specified location at a specified warming scenario. In other words, the range goes beyond these low and high points.
+
+For all current Probable Futures maps with low and high values, the low and high are 5th and 95th percentile values. So, for these maps, the low and high values should be expected about 5% of the time each, on average. Lower lows and higher highs may occur as well.
+
+#### Range of expected values: applied example
+
+Consider [the number of days above 32°C (90°F) in Delhi in a 1.5°C warming scenario](https://probablefutures.org/maps/?selected_map=days_above_32c&volume=heat&warming_scenario=1.5&map_version=latest#9.18/28.5824/77.1749). In this scenario, the global average temperature is 1.5°C above the pre-industrial global average. Delhi is warmer too. It experiences new ranges of weather.
+
+As you can see by clicking on Delhi in the map linked above, Delhi with a climate of 1.5°C above the pre-industrial climate typically experiences 227 days above 32°C on average. In a warm year, about 5% of the time, Delhi experiences about 264 days above 32°C. In a cool year, about 5% of the time, Delhi experiences about 191 days above 32°C.
+
+If the warming scenario numbers increase from 1.5°C above pre-industrial to 1.6°C, 1.7°C and eventually 2°C, the range shifts warmer again. If you click the 2°C tab, you will see the range of expected values in Delhi has shifted. In this 2°C scenario, the low, mid and high number of days above 32°C is 195, 232, and 269. You can think of this as a bell curve of values shifting to the right, toward the warmer side of a graph of temperatures in a place. Often the shape of the bell curve changes as it shifts.
+
+-   `low`: This is the low value in the range. These conditions should be expected approximately 5% of the time.
+-   `mid`: This is the average or median condition. Conditions near this value should be expected in a typical year.
+-   `high`: This is the high value in the range. These conditions should be expected approximately 5% of the time.
+
+##### Note on average and median values
+When creating these maps, we realized the range of values sometimes formed a normal distribution and other times skewed toward the tail. To provide reliable expected mid values, we chose to use median on maps that tend to have ranges with long tails.
+- Maps of temperature use average
+- Maps of precipitation use median
+- Maps of dryness vary: the two maps of drought use average and the map of wildfire and water balance use median
+- The climate zones map uses average
+
 #### How we get it
 Probable Futures has a climate science partner called [Woodwell Climate Research Center](https://www.woodwellclimate.org/). Researchers at Woodwell download the data on servers hosted by the institutions mentioned above and create maps which they share with Probable Futures.
 

--- a/tilesets.md
+++ b/tilesets.md
@@ -71,34 +71,3 @@ Tileset feature attributes represent data in a Mapbox Tiling Service map. Probab
 | 3°C              | data_3c_high         |
 |                  | data_3c_low          |
 |                  | data_3c_mid          |
-
-### Range of expected values
-
-Probable Futures maps contain low, mid, and high values for each location and warming scenario. You can think of these values as a range. People must be prepared for the full range in the same way we all must be prepared for a range of weather. In other words, this range can be thought of as potential outcomes in any given year in the specified warming scenario for the specified location.
-
-In some places, the ranges of potential outcomes are wider. For those of us who live in places that can be both very hot and very cold, we know this well. We must own different types of clothing for summer and winter. In other places, ranges are narrower. In places with narrower ranges, people don't need so many different types of clothing.
-
-As the climate changes, these ranges change in every place. The range of values in the API offer an opportunity to prepare for ranges of outcomes that are manageable and to seek changes in human actions that can help avoid ranges in warming scenarios that are unmanageable.
-
-The low and high values are not the lowest or highest possible values that could occur in the specified location at a specified warming scenario. In other words, the range goes beyond these low and high points.
-
-For all current Probable Futures maps with low and high values, the low and high are 5th and 95th percentile values. So, for these maps, the low and high values should be expected about 5% of the time each, on average. Lower lows and higher highs may occur as well.
-
-#### Range of expected values: applied example
-
-Consider [the number of days above 32°C (90°F) in Delhi in a 1.5°C warming scenario](https://probablefutures.org/maps/?selected_map=days_above_32c&volume=heat&warming_scenario=1.5&map_version=latest#9.18/28.5824/77.1749). In this scenario, the global average temperature is 1.5°C above the pre-industrial global average. Delhi is warmer too. It experiences new ranges of weather.
-
-As you can see by clicking on Delhi in the map linked above, Delhi with a climate of 1.5°C above the pre-industrial climate typically experiences 227 days above 32°C on average. In a warm year, about 5% of the time, Delhi experiences about 264 days above 32°C. In a cool year, about 5% of the time, Delhi experiences about 191 days above 32°C.
-
-If the warming scenario numbers increase from 1.5°C above pre-industrial to 1.6°C, 1.7°C and eventually 2°C, the range shifts warmer again. If you click the 2°C tab, you will see the range of expected values in Delhi has shifted. In this 2°C scenario, the low, mid and high number of days above 32°C is 195, 232, and 269. You can think of this as a bell curve of values shifting to the right, toward the warmer side of a graph of temperatures in a place. Often the shape of the bell curve changes as it shifts.
-
--   `low`: This is the low value in the range. These conditions should be expected approximately 5% of the time.
--   `mid`: This is the average or median condition. Conditions near this value should be expected in a typical year.
--   `high`: This is the high value in the range. These conditions should be expected approximately 5% of the time.
-
-##### Note on average and median values
-When creating these maps, we realized the range of values sometimes formed a normal distribution and other times skewed toward the tail. To provide reliable expected mid values, we chose to use median on maps that tend to have ranges with long tails.
-- Maps of temperature use average
-- Maps of precipitation use median
-- Maps of dryness vary: the two maps of drought use average and the map of wildfire and water balance use median
-- The climate zones map uses average


### PR DESCRIPTION
1. Reorganizes most data/model related information onto the Probable Futures Data page. This makes it easier to find all info we provide about the data and adds clarity. Having some of that info on the tilesets page felt a bit out of place and made it harder to find. Absolutely open to suggestions on different ways to achieve these goals - the changes I made are just my first idea on how to try to simplify the placement of all the information we have to convey in the docs.
2. Adds definitions page. @petercroce and I felt it would be useful to have a page with some standard definitions for developers to be aware of when working with PF. This begins the page with 3 basic ones, but more can/will be added.